### PR TITLE
Fix for TypeError; message = Cannot read property 'msie' of undefined

### DIFF
--- a/AutodlFilesDownloader.js
+++ b/AutodlFilesDownloader.js
@@ -25,7 +25,7 @@
 function autodl_ajax(obj)
 {
 	// IE8 caches all Ajax requests!
-	if ($.browser.msie)
+	if $.browser={ msie: ( navigator.appName == 'Microsoft Internet Explorer') ? true : false }
 		obj.cache = false;
 
 	$.ajax(obj);


### PR DESCRIPTION
This contains a fix for the TypeError; message = Cannot read property 'msie' of undefined error that shows up in rutorrent when using the plugin.