### PR TITLE
Replace jQuery's .size() with the standard .length

### DIFF
--- a/js/AutodlIrssiTab.js
+++ b/js/AutodlIrssiTab.js
@@ -474,6 +474,6 @@ function(time, line)
 	var tbody = $("#autodl-log-tbody");
 	tbody.append(tr);
 
-	if (tbody.children().size() >= this.REMOVE_LINES_LIMIT)
-		tbody.children(":lt(" + (tbody.children().size() - this.MAX_AUTODL_IRSSI_LINES) + ")").remove();
+	if (tbody.children().length >= this.REMOVE_LINES_LIMIT)
+		tbody.children(":lt(" + (tbody.children().length - this.MAX_AUTODL_IRSSI_LINES) + ")").remove();
 }

--- a/js/Filters.js
+++ b/js/Filters.js
@@ -178,7 +178,7 @@ function()
 		return false;
 
 	var links = theContextMenu.obj.find("a");
-	var len = links.size();
+	var len = links.length;
 	if (len !== this.strings.length || $(links[len-1]).text() !== this.strings[len-1][0])
 		return false;
 

--- a/js/Trackers.js
+++ b/js/Trackers.js
@@ -355,7 +355,7 @@ function(trackerInfo, pasteGroup, textboxElem)
 
 		var textbox = $("#" + this._settingIdFromName(trackerInfo, name));
 		var ary = s.match(setting.pasteRegex);
-		if (textbox.size() > 0 && ary && ary.length > 1)
+		if (textbox.length > 0 && ary && ary.length > 1)
 			textbox.val(ary[1]);
 	}
 }


### PR DESCRIPTION
**Please read the contributing guidelines linked above before opening a pull request.**

jQuery 1.8 deprecated the use of .size() in favour of the more
standard and universal .length attribute found throughout JavaScript

jQuery 3.0 ultimately removed it. By making the conversion we can
improve compatibility with newer versions of jQuery.