### PR TITLE
Improve zero configuration interoperability

### DIFF
--- a/getConf.php
+++ b/getConf.php
@@ -51,12 +51,12 @@ function attemptZeroConfig() {
 	if (!is_readable($userInfo['dir'].'/.autodl/autodl.cfg')) {
 		throw new Exception('Zeroconfig autodl.cfg not readable');
 	}
-	$config = parse_ini_file($userInfo['dir'].'/.autodl/autodl.cfg');
+	$config = parse_ini_file($userInfo['dir'].'/.autodl/autodl.cfg', true, INI_SCANNER_RAW);
 	if ($config === false) {
 		throw new Exception('Zeroconfig failed to parse autodl.cfg');
 	}
 
-	return $config;
+	return $config['options'];
 }
 
 // Checks if there are missing PHP modules, and if so returns JSON data with an


### PR DESCRIPTION
This pull request contains 3 fixes for zero config with interesting autodl config files:

1. When people have unusual characters or unicode characters in their autodl.cfg without proper escaping
2. When people have multiple ports and passwords defined in their autodl.cfg in the wrong sections (human error)
3. When people have the port and password defined in autodl2.cfg instead of or in addition to autodl.cfg