### PR TITLE
Use plugin.info to check for required PHP extensions

### DIFF
--- a/getConf.php
+++ b/getConf.php
@@ -80,23 +80,6 @@ function attemptZeroConfig() {
 	return $options;
 }
 
-// Checks if there are missing PHP modules, and if so returns JSON data with an
-// error message saying exactly which PHP modules are missing.
-function checkPhpModules() {
-	$missing = "";
-	foreach (Array('xml', 'sockets', 'json') as $module) {
-		if (!extension_loaded($module))
-			$missing = "$missing $module";
-	}
-	if ($missing === "")
-		return;
-
-	$jsonData = "{\"error\":\"Missing PHP modules:$missing\"}";
-	header('Content-Type: application/json; charset=UTF-8');
-	echo $jsonData;
-	exit(0);
-}
-
 // Sends a 304 if it's the same file (and exits) or returns if the file has changed
 // with added ETag HTTP header.
 function checkSameFile($etag, $mtime) {

--- a/getfiles.php
+++ b/getfiles.php
@@ -28,8 +28,6 @@
 
 require_once 'getConf.php';
 
-checkPhpModules();
-
 $command = Array("command" => "getfiles");
 $response = sendAutodlCommand($command);
 

--- a/plugin.info
+++ b/plugin.info
@@ -4,3 +4,4 @@ remote: ok
 need_rtorrent: 0
 version: 1.65.5
 runlevel: 10.0
+php.extensions.error: json,xml,sockets


### PR DESCRIPTION
ruTorrent already includes a mechanism for requiring PHP extensions
in plugins. Let's use that instead of rolling our own.
