### PR TITLE
Silence PHP warning on failure to connect

### DIFF
--- a/getConf.php
+++ b/getConf.php
@@ -143,7 +143,8 @@ function sendAutodlCommand($data) {
 		if ($socket === false)
 			throw new Exception("Could not create socket: " . getSocketError());
 
-		if (!socket_connect($socket, "127.0.0.1", $autodlPort))
+		// Silence the warning because we're throwing an exception on failure anyway
+		if (!@socket_connect($socket, "127.0.0.1", $autodlPort))
 			throw new Exception("Could not connect: " . getSocketError($socket));
 
 		$data['password'] = $autodlPassword;


### PR DESCRIPTION
We're already throwing an exception on failure, so the warning
is redundant and warnings cannot be caught/handled properly like
the exception already is.

The motivation for this it to improve the signal to noise ratio in
error monitoring/reporting tools when connected to ruTorrent.
