### PR TITLE
Fixes for ruTorrent jQuery & Utility commits

### DIFF
--- a/getConf.php
+++ b/getConf.php
@@ -31,11 +31,11 @@ try {
 	$autodlPort = $config['gui-server-port'];
 	$autodlPassword = $config['gui-server-password'];
 } catch (Exception $e) {
-	eval(getPluginConf('autodl-irssi'));
+	eval(FileUtil::getPluginConf('autodl-irssi'));
 }
 
 function attemptZeroConfig() {
-	if (!isLocalMode()) {
+	if (!User::isLocalMode()) {
 		throw new Exception('Zeroconfig is not available for remote connections');
 	}
 

--- a/init.js
+++ b/init.js
@@ -151,11 +151,10 @@ function()
 	this.addSeparatorToToolbar(beforeId);
 
 	var this_ = this;
-	$("#mnu_autodl-tb").click(function(e)
+	$("#mnu_autodl-tb").on('click', function(e)
 	{
 		this_._onClickToolbarButton(e);
-	}).
-	mouseup(function(e)
+	}).on('mouseup', function(e)
 	{
 		// Prevent ruTorrent from closing the popup menu
 		e.stopPropagation();

--- a/js/AutodlIrssiTab.js
+++ b/js/AutodlIrssiTab.js
@@ -103,7 +103,7 @@ function AutodlIrssiTab(dialogManager, plugin)
 		'</div>'
 	).get(0), "autodl-irssi", "lcont");
 
-	$("#autodl-restore").submit(function()
+	$("#autodl-restore").on('submit', function()
 	{
 		if ($("#autodl-restore-file").val() == "")
 		{
@@ -113,23 +113,23 @@ function AutodlIrssiTab(dialogManager, plugin)
 		dialogManager.clearConfigFileCache();
 		return true;
 	});
-	$("#autodl-log-backup-button").click(function()
+	$("#autodl-log-backup-button").on('click', function()
 	{
 		backupIframe.attr("src", "plugins/autodl-irssi/getfile.php?file=autodl.cfg");
 	});
-	$("#autodl-log-update-button").click(function()
+	$("#autodl-log-update-button").on('click', function()
 	{
 		this_._sendAutodlCommand("update");
 	});
-	$("#autodl-log-whatsnew-button").click(function()
+	$("#autodl-log-whatsnew-button").on('click', function()
 	{
 		this_._sendAutodlCommand("whatsnew");
 	});
-	$("#autodl-log-version-button").click(function()
+	$("#autodl-log-version-button").on('click', function()
 	{
 		this_._sendAutodlCommand("version");
 	});
-	$("#autodl-log-reload-trackers-button").click(function()
+	$("#autodl-log-reload-trackers-button").on('click', function()
 	{
 		this_._sendAutodlCommand("reloadtrackers");
 	});
@@ -137,7 +137,7 @@ function AutodlIrssiTab(dialogManager, plugin)
 	this._initResizeBottom();
 	this._initOnShow();
 
-	$("#autodl-log-clear-button").click(function(e)
+	$("#autodl-log-clear-button").on('click', function(e)
 	{
 		$("#autodl-log-tbody").empty();
 	});

--- a/js/DialogUtils.js
+++ b/js/DialogUtils.js
@@ -168,9 +168,9 @@ function DropDownBox(id)
 	this.selectedIndex = -1;
 
 	var this_ = this;
-	$(this.selectElem).change(function(e) { this_._onChange(); })
+	$(this.selectElem).on('change', function(e) { this_._onChange(); })
 						// selectedIndex should be updated when we get a keyup event
-					  .keyup(function(e) { this_._onChange(); });
+					  .on('keyup', function(e) { this_._onChange(); });
 }
 
 DropDownBox.prototype._onChange =
@@ -286,7 +286,7 @@ function SyncTextBoxes(ids)
 		(function(i, textbox)
 		{
 			this_.textboxElems.push(textbox);
-			$(textbox).keyup(function(e) { this_.setNewValue(i); })
+			$(textbox).on('keyup', function(e) { this_.setNewValue(i); })
 		})(i, document.getElementById(ids[i]));
 	}
 }

--- a/js/Filters.js
+++ b/js/Filters.js
@@ -474,7 +474,7 @@ function(multiSelectDlgBox, okHandler)
 							'<tr>' +
 								'<td>' +
 									'<label for="autodl-filters-scene">' + theUILang.autodlScene + '</label>' +
-									'<select id="autodl-filters-scene"></input>' +
+									'<select id="autodl-filters-scene"></select>' +
 									'<label for="autodl-filters-origins">' + theUILang.autodlOrigins + '</label>' +
 									'<input type="text" class="textbox-16" id="autodl-filters-origins" title="' + theUILang.autodlTitle60 + '"placeholder="' + theUILang.autodlHint35 + '"></input>' +
 								'</td>' +

--- a/js/Filters.js
+++ b/js/Filters.js
@@ -149,11 +149,11 @@ function MenuButton(buttonId, textboxId, strings, onlyAppendValues, sortIt)
 	}
 
 	var this_ = this;
-	$(this.buttonElem).click(function(e)
+	$(this.buttonElem).on('click', function(e)
 	{
 		this_._onClick(e);
 	});
-	$(this.buttonElem).mouseup(function(e)
+	$(this.buttonElem).on('mouseup', function(e)
 	{
 		// Prevent ruTorrent from immediately closing the popup menu!
 		e.stopPropagation();
@@ -270,7 +270,7 @@ function SitesButton(buttonId, textboxId, multiSelectDlgBox)
 	this.multiSelectDlgBox = multiSelectDlgBox;
 
 	var this_ = this;
-	$(this.buttonElem).click(function(e)
+	$(this.buttonElem).on('click', function(e)
 	{
 		this_._onClick(e);
 	});
@@ -351,12 +351,12 @@ function(multiSelectDlgBox, okHandler)
 	theDialogManager.make("autodl-filters", theUILang.autodlFilters,
 		'<div id="autodl-filters">' +
 			'<div id="autodl-filters-left">' +
-				'<div id="autodl-filters-list" />' +
+				'<div id="autodl-filters-list"></div>' +
 				'<div id="autodl-filters-list-buttons" align="center">' +
 					'<div>' +
-						'<input type="button" class="Button autodl-filters-button" id="autodl-filters-new-button" value="' + theUILang.autodlNew + '" />' +
-						'<input type="button" class="Button autodl-filters-button" id="autodl-filters-remove-button" value="' + theUILang.autodlRemove + '" />' +
-						'<input type="button" class="Button autodl-filters-button" id="autodl-filters-copy-button" value="' + theUILang.autodlCopy + '" />' +
+						'<input type="button" class="Button autodl-filters-button" id="autodl-filters-new-button" value="' + theUILang.autodlNew + '"></input>' +
+						'<input type="button" class="Button autodl-filters-button" id="autodl-filters-remove-button" value="' + theUILang.autodlRemove + '"></input>' +
+						'<input type="button" class="Button autodl-filters-button" id="autodl-filters-copy-button" value="' + theUILang.autodlCopy + '"></input>' +
 					'</div>' +
 				'</div>' +
 			'</div>' +
@@ -378,11 +378,11 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-name">' + theUILang.autodlDisplayName + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-name" title="' + theUILang.autodlTitle1 + '" placeholder="' + theUILang.autodlHint1 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-name" title="' + theUILang.autodlTitle1 + '" placeholder="' + theUILang.autodlHint1 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-priority">' + theUILang.autodlFiltersPriority + '</label></td>' +
-									'<td><input type="text" class="textbox-3" id="autodl-filters-priority" title="' + theUILang.autodlTitle66 + '"/></td>' +
+									'<td><input type="text" class="textbox-3" id="autodl-filters-priority" title="' + theUILang.autodlTitle66 + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -390,20 +390,20 @@ function(multiSelectDlgBox, okHandler)
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-match-sites-button" class="Button" value="' + theUILang.autodlMatchSites + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-match-sites" title="' + theUILang.autodlTitle4 + '" placeholder="' + theUILang.autodlHint4 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-match-sites-button" class="Button" value="' + theUILang.autodlMatchSites + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-match-sites" title="' + theUILang.autodlTitle4 + '" placeholder="' + theUILang.autodlHint4 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-except-sites-button" class="Button" value="' + theUILang.autodlExceptSites + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-except-sites" title="' + theUILang.autodlTitle24 + '" placeholder="' + theUILang.autodlHint23 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-except-sites-button" class="Button" value="' + theUILang.autodlExceptSites + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-except-sites" title="' + theUILang.autodlTitle24 + '" placeholder="' + theUILang.autodlHint23 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-min-size">' + theUILang.autodlMinimumSize + '</label></td>' +
-									'<td><input type="text" class="textbox-16" id="autodl-filters-min-size" title="' + theUILang.autodlTitle5 + '" placeholder="' + theUILang.autodlHint5 + '"/></td>' +
+									'<td><input type="text" class="textbox-16" id="autodl-filters-min-size" title="' + theUILang.autodlTitle5 + '" placeholder="' + theUILang.autodlHint5 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-max-size">' + theUILang.autodlMaximumSize + '</label></td>' +
-									'<td><input type="text" class="textbox-16" id="autodl-filters-max-size" title="' + theUILang.autodlTitle6 + '" placeholder="' + theUILang.autodlHint6 + '"/></td>' +
+									'<td><input type="text" class="textbox-16" id="autodl-filters-max-size" title="' + theUILang.autodlTitle6 + '" placeholder="' + theUILang.autodlHint6 + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -412,21 +412,21 @@ function(multiSelectDlgBox, okHandler)
 								'<tr>' +
 									'<td>' +
 										'<label for="autodl-filters-upload-delay-secs">' + theUILang.autodlUploadDelay + '</label>' +
-										'<input type="text" class="textbox-5" id="autodl-filters-upload-delay-secs" title="' + theUILang.autodlUploadDelay2 + '" />' +
+										'<input type="text" class="textbox-5" id="autodl-filters-upload-delay-secs" title="' + theUILang.autodlUploadDelay2 + '"></input>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td>' +
 										'<label for="autodl-filters-max-downloads">' + theUILang.autodlMaxDownloads + '</label>' +
-										'<input type="text" class="textbox-5" id="autodl-filters-max-downloads" title="' + theUILang.autodlMaxDownloadsTitle + '" />' +
+										'<input type="text" class="textbox-5" id="autodl-filters-max-downloads" title="' + theUILang.autodlMaxDownloadsTitle + '"></input>' +
 										'<label for="autodl-filters-max-downloads-per">' + theUILang.autodlMaxDownloads2 + '</label>' +
-										'<select id="autodl-filters-max-downloads-per" />' +
+										'<select id="autodl-filters-max-downloads-per"></select>' +
 										'<label for="autodl-filters-max-downloads-per">' + theUILang.autodlMaxDownloads3 + '</label>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td>' +
-										'<input type="checkbox" id="autodl-filters-download-duplicates" title="' + theUILang.autodlTitle33 + '"/>' +
+										'<input type="checkbox" id="autodl-filters-download-duplicates" title="' + theUILang.autodlTitle33 + '"></input>' +
 										'<label for="autodl-filters-download-duplicates" title="' + theUILang.autodlTitle33 + '">' + theUILang.autodlDownloadDupes + '</label>' +
 									'</td>' +
 								'</tr>' +
@@ -439,15 +439,15 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-match-releases">' + theUILang.autodlMatchReleases + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-match-releases" title="' + theUILang.autodlTitle2 + '" placeholder="' + theUILang.autodlHint2 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-match-releases" title="' + theUILang.autodlTitle2 + '" placeholder="' + theUILang.autodlHint2 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-except-releases">' + theUILang.autodlExceptReleases + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-except-releases" title="' + theUILang.autodlTitle3 + '" placeholder="' + theUILang.autodlHint3 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-except-releases" title="' + theUILang.autodlTitle3 + '" placeholder="' + theUILang.autodlHint3 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td>' +
-										'<input type="checkbox" id="autodl-filters-use-regex" title="' + theUILang.autodlTitle63 + '"/>' +
+										'<input type="checkbox" id="autodl-filters-use-regex" title="' + theUILang.autodlTitle63 + '"></input>' +
 										'<label for="autodl-filters-use-regex" title="' + theUILang.autodlTitle63 + '">' + theUILang.autodlFiltersUseRegex + '</label>' +
 									'</td>' +
 								'</tr>' +
@@ -458,15 +458,15 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-match-release-groups">' + theUILang.autodlMatchReleaseGroups + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-match-release-groups" title="' + theUILang.autodlTitle65 + '" placeholder="' + theUILang.autodlHint38 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-match-release-groups" title="' + theUILang.autodlTitle65 + '" placeholder="' + theUILang.autodlHint38 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-except-release-groups">' + theUILang.autodlExceptReleaseGroups + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-except-release-groups" title="' + theUILang.autodlTitle65 + '" placeholder="' + theUILang.autodlHint38 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-except-release-groups" title="' + theUILang.autodlTitle65 + '" placeholder="' + theUILang.autodlHint38 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-max-pretime">' + theUILang.autodlMaxPreTime + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-max-pretime" title="' + theUILang.autodlTitle25 + '" placeholder="' + theUILang.autodlHint24 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-max-pretime" title="' + theUILang.autodlTitle25 + '" placeholder="' + theUILang.autodlHint24 + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -474,17 +474,17 @@ function(multiSelectDlgBox, okHandler)
 							'<tr>' +
 								'<td>' +
 									'<label for="autodl-filters-scene">' + theUILang.autodlScene + '</label>' +
-									'<select id="autodl-filters-scene" />' +
+									'<select id="autodl-filters-scene"></input>' +
 									'<label for="autodl-filters-origins">' + theUILang.autodlOrigins + '</label>' +
-									'<input type="text" class="textbox-16" id="autodl-filters-origins" title="' + theUILang.autodlTitle60 + '"placeholder="' + theUILang.autodlHint35 + '"/>' +
+									'<input type="text" class="textbox-16" id="autodl-filters-origins" title="' + theUILang.autodlTitle60 + '"placeholder="' + theUILang.autodlHint35 + '"></input>' +
 								'</td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td>' +
 									'<label for="autodl-filters-freeleech">' + theUILang.autodlFreeleech + '</label>' +
-									'<select id="autodl-filters-freeleech" />' +
+									'<select id="autodl-filters-freeleech"></select>' +
 									'<label for="autodl-filters-feeleech-percents">' + theUILang.autodlFreeleechPercents + '</label>' +
-									'<input type="text" class="textbox-16" id="autodl-filters-freeleech-percents" title="' + theUILang.autodlTitle58 + '" placeholder="' + theUILang.autodlHint33 + '"/>' +
+									'<input type="text" class="textbox-16" id="autodl-filters-freeleech-percents" title="' + theUILang.autodlTitle58 + '" placeholder="' + theUILang.autodlHint33 + '"></input>' +
 								'</td>' +
 							'</tr>' +
 						'</table>' +
@@ -494,7 +494,7 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-shows">' + theUILang.autodlTvShowMovie + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-shows" title="' + theUILang.autodlTitle7 + '" placeholder="' + theUILang.autodlHint7 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-shows" title="' + theUILang.autodlTitle7 + '" placeholder="' + theUILang.autodlHint7 + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -503,15 +503,15 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-seasons">' + theUILang.autodlSeasons + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-seasons" title="' + theUILang.autodlTitle8 + '" placeholder="' + theUILang.autodlHint8 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-seasons" title="' + theUILang.autodlTitle8 + '" placeholder="' + theUILang.autodlHint8 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-episodes">' + theUILang.autodlEpisodes + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-episodes" title="' + theUILang.autodlTitle9 + '" placeholder="' + theUILang.autodlHint9 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-episodes" title="' + theUILang.autodlTitle9 + '" placeholder="' + theUILang.autodlHint9 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td>' +
-										'<input type="checkbox" id="autodl-filters-smart-episode" title="' + theUILang.autodlTitle67 + '"/>' +
+										'<input type="checkbox" id="autodl-filters-smart-episode" title="' + theUILang.autodlTitle67 + '"></input>' +
 										'<label for="autodl-filters-smart-episode" title="' + theUILang.autodlTitle67 + '">' + theUILang.autodlSmartEpisode + '</label>' +
 									'</td>' +
 								'</tr>' +
@@ -521,24 +521,24 @@ function(multiSelectDlgBox, okHandler)
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-resolutions-button" class="Button" value="' + theUILang.autodlResolutions + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-resolutions" title="' + theUILang.autodlTitle10 + '" placeholder="' + theUILang.autodlHint10 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-resolutions-button" class="Button" value="' + theUILang.autodlResolutions + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-resolutions" title="' + theUILang.autodlTitle10 + '" placeholder="' + theUILang.autodlHint10 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-encoders-button" class="Button" value="' + theUILang.autodlEncoders + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-encoders" title="' + theUILang.autodlTitle11 + '" placeholder="' + theUILang.autodlHint11 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-encoders-button" class="Button" value="' + theUILang.autodlEncoders + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-encoders" title="' + theUILang.autodlTitle11 + '" placeholder="' + theUILang.autodlHint11 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-sources-button" class="Button" value="' + theUILang.autodlSources + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-sources" title="' + theUILang.autodlTitle12 + '" placeholder="' + theUILang.autodlHint12 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-sources-button" class="Button" value="' + theUILang.autodlSources + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-sources" title="' + theUILang.autodlTitle12 + '" placeholder="' + theUILang.autodlHint12 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-containers">' + theUILang.autodlContainers + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-containers" title="' + theUILang.autodlTitle62 + '" placeholder="' + theUILang.autodlHint36 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-containers" title="' + theUILang.autodlTitle62 + '" placeholder="' + theUILang.autodlHint36 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-years1">' + theUILang.autodlYears + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-years1" title="' + theUILang.autodlTitle13 + '" placeholder="' + theUILang.autodlHint13 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-years1" title="' + theUILang.autodlTitle13 + '" placeholder="' + theUILang.autodlHint13 + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -548,35 +548,35 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-years2">' + theUILang.autodlYears + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-years2" title="' + theUILang.autodlTitle13 + '" placeholder="' + theUILang.autodlHint13 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-years2" title="' + theUILang.autodlTitle13 + '" placeholder="' + theUILang.autodlHint13 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-artists">' + theUILang.autodlArtists + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-artists" title="' + theUILang.autodlTitle14 + '" placeholder="' + theUILang.autodlHint14 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-artists" title="' + theUILang.autodlTitle14 + '" placeholder="' + theUILang.autodlHint14 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-albums">' + theUILang.autodlAlbums + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-albums" title="' + theUILang.autodlTitle15 + '" placeholder="' + theUILang.autodlHint15 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-albums" title="' + theUILang.autodlTitle15 + '" placeholder="' + theUILang.autodlHint15 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-formats-button" class="Button" value="' + theUILang.autodlFormats + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-formats" title="' + theUILang.autodlTitle16 + '" placeholder="' + theUILang.autodlHint16 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-formats-button" class="Button" value="' + theUILang.autodlFormats + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-formats" title="' + theUILang.autodlTitle16 + '" placeholder="' + theUILang.autodlHint16 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-bitrates-button" class="Button" value="' + theUILang.autodlBitrates + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-bitrates" title="' + theUILang.autodlTitle17 + '" placeholder="' + theUILang.autodlHint17 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-bitrates-button" class="Button" value="' + theUILang.autodlBitrates + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-bitrates" title="' + theUILang.autodlTitle17 + '" placeholder="' + theUILang.autodlHint17 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td><input type="button" id="autodl-filters-media-button" class="Button" value="' + theUILang.autodlMedia + '" /></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-media" title="' + theUILang.autodlTitle18 + '" placeholder="' + theUILang.autodlHint18 + '"/></td>' +
+									'<td><input type="button" id="autodl-filters-media-button" class="Button" value="' + theUILang.autodlMedia + '"></input></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-media" title="' + theUILang.autodlTitle18 + '" placeholder="' + theUILang.autodlHint18 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-match-release-types">' + theUILang.autodlMatchReleaseTypes + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-match-release-types" title="' + theUILang.autodlTitle64 + '" placeholder="' + theUILang.autodlHint37 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-match-release-types" title="' + theUILang.autodlTitle64 + '" placeholder="' + theUILang.autodlHint37 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-except-release-types">' + theUILang.autodlExceptReleaseTypes + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-except-release-types" title="' + theUILang.autodlTitle64 + '" placeholder="' + theUILang.autodlHint37 + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-except-release-types" title="' + theUILang.autodlTitle64 + '" placeholder="' + theUILang.autodlHint37 + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -584,15 +584,15 @@ function(multiSelectDlgBox, okHandler)
 							'<tr>' +
 								'<td>' +
 									'<label for="autodl-filters-cue">Cue</label>' +
-									'<select id="autodl-filters-cue" />' +
+									'<select id="autodl-filters-cue"></select>' +
 								'</td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td>' +
 									'<label for="autodl-filters-log">Log</label>' +
-									'<select id="autodl-filters-log" />' +
+									'<select id="autodl-filters-log"></select>' +
 									'<label for="autodl-filters-log-scores">' + theUILang.autodlLogScores + '</label>' +
-									'<input type="text" class="textbox-16" id="autodl-filters-log-scores" title="' + theUILang.autodlTitle59 + '" placeholder="' + theUILang.autodlHint34 + '"/>' +
+									'<input type="text" class="textbox-16" id="autodl-filters-log-scores" title="' + theUILang.autodlTitle59 + '" placeholder="' + theUILang.autodlHint34 + '"></input>' +
 								'</td>' +
 							'</tr>' +
 						'</table>' +
@@ -602,38 +602,38 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-match-categories">' + theUILang.autodlMatchCategories + '</label></td>' +
-									'<td><input type="text" class="textbox-20" id="autodl-filters-match-categories" title="' + theUILang.autodlTitle20 + '" placeholder="' + theUILang.autodlHint19 + '"/></td>' +
+									'<td><input type="text" class="textbox-20" id="autodl-filters-match-categories" title="' + theUILang.autodlTitle20 + '" placeholder="' + theUILang.autodlHint19 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-except-categories">' + theUILang.autodlExceptCategories + '</label></td>' +
-									'<td><input type="text" class="textbox-20" id="autodl-filters-except-categories" title="' + theUILang.autodlTitle21 + '" placeholder="' + theUILang.autodlHint20 + '"/></td>' +
+									'<td><input type="text" class="textbox-20" id="autodl-filters-except-categories" title="' + theUILang.autodlTitle21 + '" placeholder="' + theUILang.autodlHint20 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-match-uploaders">' + theUILang.autodlMatchUploaders + '</label></td>' +
-									'<td><input type="text" class="textbox-20" id="autodl-filters-match-uploaders" title="' + theUILang.autodlTitle22 + '" placeholder="' + theUILang.autodlHint21 + '"/></td>' +
+									'<td><input type="text" class="textbox-20" id="autodl-filters-match-uploaders" title="' + theUILang.autodlTitle22 + '" placeholder="' + theUILang.autodlHint21 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-except-uploaders">' + theUILang.autodlExceptUploaders + '</label></td>' +
-									'<td><input type="text" class="textbox-20" id="autodl-filters-except-uploaders" title="' + theUILang.autodlTitle23 + '" placeholder="' + theUILang.autodlHint22 + '"/></td>' +
+									'<td><input type="text" class="textbox-20" id="autodl-filters-except-uploaders" title="' + theUILang.autodlTitle23 + '" placeholder="' + theUILang.autodlHint22 + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-tags">' + theUILang.autodlTags + '</label></td>' +
 									'<td>' +
-										'<input type="text" class="textbox-16" id="autodl-filters-tags" title="' + theUILang.autodlTitle19 + '" placeholder="' + theUILang.autodlHint25 + '"/>' +
-										'<select id="autodl-filters-tags-any" />' +
+										'<input type="text" class="textbox-16" id="autodl-filters-tags" title="' + theUILang.autodlTitle19 + '" placeholder="' + theUILang.autodlHint25 + '"></input>' +
+										'<select id="autodl-filters-tags-any"></select>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-except-tags">' + theUILang.autodlExceptTags + '</label></td>' +
 									'<td>' +
-										'<input type="text" class="textbox-16" id="autodl-filters-except-tags" title="' + theUILang.autodlTitle57 + '" placeholder="' + theUILang.autodlHint25 + '"/>' +
-										'<select id="autodl-filters-except-tags-any" />' +
+										'<input type="text" class="textbox-16" id="autodl-filters-except-tags" title="' + theUILang.autodlTitle57 + '" placeholder="' + theUILang.autodlHint25 + '"></input>' +
+										'<select id="autodl-filters-except-tags-any"></select>' +
 									'</td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
 					'</div>' +
-					'<div id="autodl-filters-contents-upload"/>' +
+					'<div id="autodl-filters-contents-upload"></div>' +
 					'<div id="autodl-filters-contents-wol">' +
 						'<p>' +
 							theUILang.autodlWolDesc +
@@ -642,15 +642,15 @@ function(multiSelectDlgBox, okHandler)
 							'<tbody>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-wol-mac">' + theUILang.autodlWolMac + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-wol-mac" title="' + theUILang.autodlWolMacTitle + '" placeholder="' + theUILang.autodlWolMacEmpty + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-wol-mac" title="' + theUILang.autodlWolMacTitle + '" placeholder="' + theUILang.autodlWolMacEmpty + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-wol-ip">' + theUILang.autodlWolIp + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-wol-ip" title="' + theUILang.autodlWolIpTitle + '" placeholder="' + theUILang.autodlWolIpEmpty + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-wol-ip" title="' + theUILang.autodlWolIpTitle + '" placeholder="' + theUILang.autodlWolIpEmpty + '"></input></td>' +
 								'</tr>' +
 								'<tr>' +
 									'<td><label for="autodl-filters-wol-port">' + theUILang.autodlWolPort + '</label></td>' +
-									'<td><input type="text" class="textbox-23" id="autodl-filters-wol-port" title="' + theUILang.autodlWolPortTitle + '" placeholder="' + theUILang.autodlWolPortEmpty + '"/></td>' +
+									'<td><input type="text" class="textbox-23" id="autodl-filters-wol-port" title="' + theUILang.autodlWolPortTitle + '" placeholder="' + theUILang.autodlWolPortEmpty + '"></input></td>' +
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
@@ -658,8 +658,8 @@ function(multiSelectDlgBox, okHandler)
 				'</div>' +
 			'</div>' +
 			'<div class="aright buttons-list dialog-buttons">' +
-				'<input type="button" id="autodl-filters-ok-button" value="' + theUILang.ok + '" class="OK Button" />' +
-				'<input type="button" id="autodl-filters-cancel-button" value="' + theUILang.Cancel + '" class="Cancel Button" />' +
+				'<input type="button" id="autodl-filters-ok-button" value="' + theUILang.ok + '" class="OK Button" ></input>' +
+				'<input type="button" id="autodl-filters-cancel-button" value="' + theUILang.Cancel + '" class="Cancel Button"></input>' +
 			'</div>' +
 		'</div>'
 	);
@@ -713,19 +713,19 @@ function(multiSelectDlgBox, okHandler)
 
 	var this_ = this;
 
-	$("#autodl-filters-new-button").click(function(e)
+	$("#autodl-filters-new-button").on('click', function(e)
 	{
 		this_._onClickNew();
 	});
-	$("#autodl-filters-remove-button").click(function(e)
+	$("#autodl-filters-remove-button").on('click', function(e)
 	{
 		this_._onClickRemove();
 	});
-	$("#autodl-filters-copy-button").click(function(e)
+	$("#autodl-filters-copy-button").on('click', function(e)
 	{
 		this_._onClickCopy();
 	});
-	$("#autodl-filters-name").keyup(function(e)
+	$("#autodl-filters-name").on('keyup', function(e)
 	{
 		this_._onFilterNameModified();
 	});
@@ -778,7 +778,7 @@ function(multiSelectDlgBox, okHandler)
 
 	this.uploadMethod = new UploadMethod("autodl-filters", "autodl-filters-contents-upload");
 
-	$("#autodl-filters-ok-button").click(function(e) { okHandler() });
+	$("#autodl-filters-ok-button").on('click', function(e) { okHandler() });
 }
 
 Filters.prototype.onBeforeShow =
@@ -870,8 +870,8 @@ function(section)
 		section: section,
 		idNum: this.nextId
 	};
-	obj.checkboxElem = $('<input type="checkbox" />')[0];
-	obj.labelElem = $('<label />').text(this._fixFilterName(section.name))[0];
+	obj.checkboxElem = $('<input type="checkbox"></input>')[0];
+	obj.labelElem = $('<label></label>').text(this._fixFilterName(section.name))[0];
 
 	if (section.getOption("enabled", "true", "bool").getValue())
 		$(obj.checkboxElem).attr("checked", "checked");

--- a/js/IrcServers.js
+++ b/js/IrcServers.js
@@ -32,14 +32,14 @@ function(multiSelectDlgBox, okHandler)
 	theDialogManager.make("autodl-ircsrvs", theUILang.autodlIrcServers,
 		'<div id="autodl-ircsrvs">' +
 			'<div id="autodl-ircsrvs-left">' +
-				'<div id="autodl-ircsrvs-list" />' +
+				'<div id="autodl-ircsrvs-list"></div>' +
 				'<div id="autodl-ircsrvs-list-buttons" align="center">' +
 					'<div>' +
-						'<input type="button" class="Button" id="autodl-ircsrvs-new-button" value="' + theUILang.autodlNew + '" />' +
-						'<input type="button" class="Button" id="autodl-ircsrvs-remove-button" value="' + theUILang.autodlRemove + '" />' +
+						'<input type="button" class="Button" id="autodl-ircsrvs-new-button" value="' + theUILang.autodlNew + '"></input>' +
+						'<input type="button" class="Button" id="autodl-ircsrvs-remove-button" value="' + theUILang.autodlRemove + '"></input>' +
 					'</div>' +
 					'<div>' +
-						'<input type="button" class="Button" id="autodl-ircsrvs-announce-channels-button" value="' + theUILang.autodlServers2 + '" />' +
+						'<input type="button" class="Button" id="autodl-ircsrvs-announce-channels-button" value="' + theUILang.autodlServers2 + '"></input>' +
 					'</div>' +
 				'</div>' +
 			'</div>' +
@@ -48,65 +48,65 @@ function(multiSelectDlgBox, okHandler)
 					'<legend>' + theUILang.autodlIrcsrvs1 + '</legend>' +
 					'<div>' +
 						'<label for="autodl-ircsrvs-server">' + theUILang.autodlIrcsrvs2 + '</label>' +
-						'<input type="text" class="textbox-12" id="autodl-ircsrvs-server" title="' + theUILang.autodlIrcsrvs3 + '" placeholder="' + theUILang.autodlIrcsrvs4 + '"/>' +
+						'<input type="text" class="textbox-12" id="autodl-ircsrvs-server" title="' + theUILang.autodlIrcsrvs3 + '" placeholder="' + theUILang.autodlIrcsrvs4 + '"></input>' +
 						'<label for="autodl-ircsrvs-port">' + theUILang.autodlIrcsrvs5 + '</label>' +
-						'<input type="text" class="textbox-5" id="autodl-ircsrvs-port" title="' + theUILang.autodlIrcsrvs6 + '" placeholder="' + theUILang.autodlIrcsrvs7 + '"/>' +
-						'<input type="checkbox" id="autodl-ircsrvs-ssl" title="' + theUILang.autodlIrcsrvs8 + '"/>' +
+						'<input type="text" class="textbox-5" id="autodl-ircsrvs-port" title="' + theUILang.autodlIrcsrvs6 + '" placeholder="' + theUILang.autodlIrcsrvs7 + '"></input>' +
+						'<input type="checkbox" id="autodl-ircsrvs-ssl" title="' + theUILang.autodlIrcsrvs8 + '"></input>' +
 						'<label for="autodl-ircsrvs-ssl" title="' + theUILang.autodlIrcsrvs9 + '">' + theUILang.autodlIrcsrvs10 + '</label>' +
 					'</div>' +
 					'<div>' +
 						'<label for="autodl-ircsrvs-nick">' + theUILang.autodlIrcsrvs11 + '</label>' +
-						'<input type="text" class="textbox-5" id="autodl-ircsrvs-nick" title="' + theUILang.autodlIrcsrvs12 + '"/>' +
+						'<input type="text" class="textbox-5" id="autodl-ircsrvs-nick" title="' + theUILang.autodlIrcsrvs12 + '"></input>' +
 						'<label for="autodl-ircsrvs-identpass">' + theUILang.autodlPassword + '</label>' +
-						'<input type="password" class="textbox-5" id="autodl-ircsrvs-identpass" title="' + theUILang.autodlIrcsrvs14 + '"/>' +
+						'<input type="password" class="textbox-5" id="autodl-ircsrvs-identpass" title="' + theUILang.autodlIrcsrvs14 + '"></input>' +
 						'<label for="autodl-ircsrvs-identemail">' + theUILang.autodlIrcsrvs15 + '</label>' +
-						'<input type="text" class="textbox-7" id="autodl-ircsrvs-identemail" title="' + theUILang.autodlIrcsrvs16 + '"/>' +
+						'<input type="text" class="textbox-7" id="autodl-ircsrvs-identemail" title="' + theUILang.autodlIrcsrvs16 + '"></input>' +
 					'</div>' +
 					'<div>' +
 						'<label for="autodl-ircsrvs-server-password">' + theUILang.autodlIrcsrvs32 + '</label>' +
-						'<input type="text" class="textbox-12" id="autodl-ircsrvs-server-password" title="' + theUILang.autodlIrcsrvs33 + '"/>' +
-						'<input type="checkbox" id="autodl-ircsrvs-bnc" title="' + theUILang.autodlIrcsrvs34 + '"/>' +
+						'<input type="text" class="textbox-12" id="autodl-ircsrvs-server-password" title="' + theUILang.autodlIrcsrvs33 + '"></input>' +
+						'<input type="checkbox" id="autodl-ircsrvs-bnc" title="' + theUILang.autodlIrcsrvs34 + '"></input>' +
 						'<label for="autodl-ircsrvs-bnc" title="' + theUILang.autodlIrcsrvs35 + '">' + theUILang.autodlIrcsrvs36 + '</label>' +
 					'</div>' +
 				'</fieldset>' +
 				'<fieldset id="autodl-ircsrvs-channels-fieldset">' +
 					'<legend>' + theUILang.autodlIrcsrvs17 + '</legend>' +
 					'<div>' +
-						'<select id="autodl-ircsrvs-channels"/>' +
-						'<input type="button" class="Button" id="autodl-ircsrvs-new-channel-button" value="' + theUILang.autodlNew + '" />' +
-						'<input type="button" class="Button" id="autodl-ircsrvs-remove-channel-button" value="' + theUILang.autodlRemove + '" />' +
+						'<select id="autodl-ircsrvs-channels"></select>' +
+						'<input type="button" class="Button" id="autodl-ircsrvs-new-channel-button" value="' + theUILang.autodlNew + '"></input>' +
+						'<input type="button" class="Button" id="autodl-ircsrvs-remove-channel-button" value="' + theUILang.autodlRemove + '"></input>' +
 					'</div>' +
 					'<div>' +
 						'<label for="autodl-ircsrvs-channel">' + theUILang.autodlIrcsrvs18 + '</label>' +
-						'<input type="text" class="textbox-11" id="autodl-ircsrvs-channel" title="' + theUILang.autodlIrcsrvs19 + '" placeholder="' + theUILang.autodlIrcsrvs20 + '"/>' +
+						'<input type="text" class="textbox-11" id="autodl-ircsrvs-channel" title="' + theUILang.autodlIrcsrvs19 + '" placeholder="' + theUILang.autodlIrcsrvs20 + '"></input>' +
 						'<label for="autodl-ircsrvs-channelpass">' + theUILang.autodlPassword + '</label>' +
-						'<input type="password" class="textbox-8" id="autodl-ircsrvs-channelpass" title="' + theUILang.autodlIrcsrvs22 + '"/>' +
+						'<input type="password" class="textbox-8" id="autodl-ircsrvs-channelpass" title="' + theUILang.autodlIrcsrvs22 + '"></input>' +
 					'</div>' +
 					'<table>' +
 						'<tbody>' +
 							'<tr>' +
 								'<td><label for="autodl-ircsrvs-chaninvite">' + theUILang.autodlIrcsrvs23 + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-chaninvite" title="' + theUILang.autodlIrcsrvs24 + '" placeholder="' + theUILang.autodlIrcsrvs25 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-chaninvite" title="' + theUILang.autodlIrcsrvs24 + '" placeholder="' + theUILang.autodlIrcsrvs25 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-ircsrvs-httpurl">' + theUILang.autodlIrcsrvs26 + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-httpurl" title="' + theUILang.autodlIrcsrvs27 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-httpurl" title="' + theUILang.autodlIrcsrvs27 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-ircsrvs-httpheader">' + theUILang.autodlIrcsrvs28 + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-httpheader" title="' + theUILang.autodlIrcsrvs29 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-httpheader" title="' + theUILang.autodlIrcsrvs29 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-ircsrvs-httpdata">' + theUILang.autodlIrcsrvs30 + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-httpdata" title="' + theUILang.autodlIrcsrvs31 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-ircsrvs-httpdata" title="' + theUILang.autodlIrcsrvs31 + '"></input></td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>' +
 				'</fieldset>' +
 			'</div>' +
 			'<div class="aright buttons-list dialog-buttons">' +
-				'<input type="button" id="autodl-ircsrvs-ok-button" value="' + theUILang.ok + '" class="OK Button" />' +
-				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button" />' +
+				'<input type="button" id="autodl-ircsrvs-ok-button" value="' + theUILang.ok + '" class="OK Button"></input>' +
+				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button"></input>' +
 			'</div>' +
 		'</div>'
 	);
@@ -132,31 +132,31 @@ function(multiSelectDlgBox, okHandler)
 		new DialogOptionText("autodl-ircsrvs-httpdata", "invite-http-data", "")
 	];
 
-	$("#autodl-ircsrvs-new-button").click(function()
+	$("#autodl-ircsrvs-new-button").on('click', function() 
 	{
 		this_._onNewServerClicked();
 	});
-	$("#autodl-ircsrvs-remove-button").click(function()
+	$("#autodl-ircsrvs-remove-button").on('click', function()
 	{
 		this_._onRemoveServerClicked();
 	});
-	$("#autodl-ircsrvs-announce-channels-button").click(function()
+	$("#autodl-ircsrvs-announce-channels-button").on('click', function()
 	{
 		theDialogManager.show("autodl-servers");
 	});
-	$("#autodl-ircsrvs-new-channel-button").click(function()
+	$("#autodl-ircsrvs-new-channel-button").on('click', function()
 	{
 		this_._onNewChannelClicked();
 	});
-	$("#autodl-ircsrvs-remove-channel-button").click(function()
+	$("#autodl-ircsrvs-remove-channel-button").on('click', function()
 	{
 		this_._onRemoveChannelClicked();
 	});
-	$("#autodl-ircsrvs-server").keyup(function(e)
+	$("#autodl-ircsrvs-server").on('keyup', function(e)
 	{
 		this_._onServerNameModified();
 	});
-	$("#autodl-ircsrvs-channel").keyup(function(e)
+	$("#autodl-ircsrvs-channel").on('keyup', function(e)
 	{
 		this_._onChannelNameModified();
 	});
@@ -170,7 +170,7 @@ function(multiSelectDlgBox, okHandler)
 		this_.onChannelsDropDownChange(oldValue, newValue);
 	};
 
-	$("#autodl-ircsrvs-ok-button").click(function(e) { okHandler() });
+	$("#autodl-ircsrvs-ok-button").on('click', function(e) { okHandler() });
 }
 
 IrcServers.prototype.onBeforeShow =
@@ -253,8 +253,8 @@ function(serverInfo)
 	{
 		serverInfo: serverInfo
 	};
-	obj.checkboxElem = $('<input type="checkbox" />')[0];
-	obj.labelElem = $('<label />').text(this._fixName(serverInfo.serverSection.name))[0];
+	obj.checkboxElem = $('<input type="checkbox"></input>')[0];
+	obj.labelElem = $('<label></label>').text(this._fixName(serverInfo.serverSection.name))[0];
 
 	if (serverInfo.serverSection.getOption("enabled", "true", "bool").getValue())
 		$(obj.checkboxElem).attr("checked", "checked");

--- a/js/ListBox.js
+++ b/js/ListBox.js
@@ -62,7 +62,7 @@ function(elem, data)
 	$(this.lbElem).append(obj.elem);
 
 	var this_ = this;
-	$(obj.elem).click(function(e)
+	$(obj.elem).on('click', function(e)
 	{
 		this_.select(this_._findIndex(obj));
 	});

--- a/js/MultiSelect.js
+++ b/js/MultiSelect.js
@@ -26,13 +26,13 @@ function MultiSelect()
 {
 	theDialogManager.make("autodl-multiselect", theUILang.autodlSelect,
 		'<div id="autodl-multiselect">' +
-			'<div id="autodl-multiselect-title" />' +
+			'<div id="autodl-multiselect-title"></div>' +
 			'<div id="autodl-multiselect-content">' +
-				'<select multiple="multiple" id="autodl-multiselect-select" />' +
+				'<select multiple="multiple" id="autodl-multiselect-select"></select>' +
 			'</div>' +
 			'<div class="aright buttons-list dialog-buttons">' +
-				'<input type="button" id="autodl-multiselect-ok-button" value="' + theUILang.ok + '" class="OK Button" />' +
-				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button" />' +
+				'<input type="button" id="autodl-multiselect-ok-button" value="' + theUILang.ok + '" class="OK Button"></input>' +
+				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button"></input>' +
 			'</div>' +
 		'</div>', true
 	);
@@ -50,7 +50,7 @@ function MultiSelect()
 		this_.onAfterHide();
 	});
 
-	$("#autodl-multiselect-ok-button").click(function(e)
+	$("#autodl-multiselect-ok-button").on('click', function(e)
 	{
 		this_._onClickOk();
 	});
@@ -103,7 +103,7 @@ function()
 
 	for (var i = 0; i < this.data.listboxData.length; i++)
 	{
-		var option = $('<option />').text(this.data.listboxData[i].displayName);
+		var option = $('<option></option>').text(this.data.listboxData[i].displayName);
 		if (isSelected(this.data.listboxData[i].validNames))
 			option.attr("selected", "selected");
 		$(this.selectElem).append(option);

--- a/js/Preferences.js
+++ b/js/Preferences.js
@@ -33,7 +33,7 @@ function SitesButton(buttonId, textboxId, multiSelectDlgBox)
 	this.multiSelectDlgBox = multiSelectDlgBox;
 
 	var this_ = this;
-	$(this.buttonElem).click(function(e)
+	$(this.buttonElem).on('click', function(e)
 	{
 		this_._onClick(e);
 	});
@@ -101,59 +101,59 @@ function(multiSelectDlgBox, okHandler)
 				'<div id="autodl-prefs-contents-general">' +
 					'<div>' +
 						'<td><label for="autodl-max-saved-releases">' + theUILang.autodlMaxSavedRels + '</label></td>' +
-						'<td><input type="text" class="textbox-13" id="autodl-max-saved-releases" title="' + theUILang.autodlTitle31 + '"/></td>' +
+						'<td><input type="text" class="textbox-13" id="autodl-max-saved-releases" title="' + theUILang.autodlTitle31 + '"></input></td>' +
 					'</div>' +
 					'<div>' +
 						'<td>' +
-							'<input type="checkbox" id="autodl-save-download-history" title="' + theUILang.autodlTitle32 + '"/>' +
+							'<input type="checkbox" id="autodl-save-download-history" title="' + theUILang.autodlTitle32 + '"></input>' +
 							'<label for="autodl-save-download-history" title="' + theUILang.autodlTitle32 + '">' + theUILang.autodlSaveDlHist + '</label>' +
 						'</td>' +
 					'</div>' +
 					'<div>' +
 						'<td>' +
-							'<input type="checkbox" id="autodl-download-duplicates" title="' + theUILang.autodlTitle33 + '"/>' +
+							'<input type="checkbox" id="autodl-download-duplicates" title="' + theUILang.autodlTitle33 + '"></input>' +
 							'<label for="autodl-download-duplicates" title="' + theUILang.autodlTitle33 + '">' + theUILang.autodlDownloadDupes + '</label>' +
 						'</td>' +
 					'</div>' +
 					'<div>' +
 						'<td>' +
-							'<input type="checkbox" id="autodl-use-regex" title="' + theUILang.autodlTitle63 + '"/>' +
+							'<input type="checkbox" id="autodl-use-regex" title="' + theUILang.autodlTitle63 + '"></input>' +
 							'<label for="autodl-use-regex" title="' + theUILang.autodlTitle63 + '">' + theUILang.autodlUseRegex + '</label>' +
 						'</td>' +
 					'</div>' +
 					'<div>' +
 						'<td>' +
-							'<input type="checkbox" id="autodl-unique-name" title="' + theUILang.autodlUniqueNameTitle + '"/>' +
+							'<input type="checkbox" id="autodl-unique-name" title="' + theUILang.autodlUniqueNameTitle + '"></input>' +
 							'<label for="autodl-unique-name" title="' + theUILang.autodlUniqueNameTitle + '">' + theUILang.autodlUniqueName + '</label>' +
 						'</td>' +
 					'</div>' +
 					'<div>' +
 						'<td>' +
 							'<label for="autodl-automatic-updates">' + theUILang.autodlAutomaticUpdates + '</label>' +
-							'<select id="autodl-automatic-updates" />' +
+							'<select id="autodl-automatic-updates"></select>' +
 						'</td>' +
 					'</div>' +
 				'</div>' +
-				'<div id="autodl-prefs-contents-upload"/>' +
+				'<div id="autodl-prefs-contents-upload"></div>' +
 				'<div id="autodl-prefs-contents-webui">' +
 					'<p>' + theUILang.autodlOnlyUtorrentWebui2 + '</p>' +
 					'<table>' +
 						'<tbody>' +
 							'<tr>' +
 								'<td><label for="autodl-webui-user">' + theUILang.autodlUserName + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-webui-user" title="' + theUILang.autodlTitle34 + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-webui-user" title="' + theUILang.autodlTitle34 + '"></input></td>' +
 								'<td><label for="autodl-webui-password">' + theUILang.autodlPassword + '</label></td>' +
-								'<td><input type="password" class="textbox-13" id="autodl-webui-password" title="' + theUILang.autodlTitle35 + '"/></td>' +
+								'<td><input type="password" class="textbox-13" id="autodl-webui-password" title="' + theUILang.autodlTitle35 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-webui-hostname">' + theUILang.autodlIpAddress + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-webui-hostname" title="' + theUILang.autodlTitle36 + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-webui-hostname" title="' + theUILang.autodlTitle36 + '"></input></td>' +
 								'<td><label for="autodl-webui-port">' + theUILang.autodlPort + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-webui-port" title="' + theUILang.autodlTitle37 + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-webui-port" title="' + theUILang.autodlTitle37 + '"></input></td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>' +
-					'<input type="checkbox" id="autodl-webui-ssl" />' +
+					'<input type="checkbox" id="autodl-webui-ssl"></input>' +
 					'<label for="autodl-webui-ssl">' + theUILang.autodlUseSsl + '</label>' +
 				'</div>' +
 				'<div id="autodl-prefs-contents-ftp">' +
@@ -161,38 +161,38 @@ function(multiSelectDlgBox, okHandler)
 						'<tbody>' +
 							'<tr>' +
 								'<td><label for="autodl-ftp-user">' + theUILang.autodlUserName + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-ftp-user" title="' + theUILang.autodlTitle38 + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-ftp-user" title="' + theUILang.autodlTitle38 + '"></input></td>' +
 								'<td><label for="autodl-ftp-password">' + theUILang.autodlPassword + '</label></td>' +
-								'<td><input type="password" class="textbox-13" id="autodl-ftp-password" title="' + theUILang.autodlTitle39 + '"/></td>' +
+								'<td><input type="password" class="textbox-13" id="autodl-ftp-password" title="' + theUILang.autodlTitle39 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-ftp-hostname">' + theUILang.autodlHostname + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-ftp-hostname" title="' + theUILang.autodlTitle40 + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-ftp-hostname" title="' + theUILang.autodlTitle40 + '"></input></td>' +
 								'<td><label for="autodl-ftp-port">' + theUILang.autodlPort + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-ftp-port" title="' + theUILang.autodlTitle41 + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-ftp-port" title="' + theUILang.autodlTitle41 + '"></input></td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>' +
 				'</div>' +
 				'<div id="autodl-prefs-contents-irc">' +
-					'<input type="checkbox" id="autodl-irc-autoconn-enabled" title="' + theUILang.autodlAutoConnEnabled + '"/>' +
+					'<input type="checkbox" id="autodl-irc-autoconn-enabled" title="' + theUILang.autodlAutoConnEnabled + '"></input>' +
 					'<label for="autodl-irc-autoconn-enabled" title="' + theUILang.autodlAutoConnEnabled + '">' + theUILang.autodlAutoConnEnabled + '</label>' +
 					'<table>' +
 						'<tbody>' +
 							'<tr>' +
 								'<td><label for="autodl-irc-user-name">' + theUILang.autodlUserName + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-irc-user-name" title="' + theUILang.autodlYourUserName + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-irc-user-name" title="' + theUILang.autodlYourUserName + '"></input></td>' +
 								'<td><label for="autodl-irc-real-name">' + theUILang.autodlRealName + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-irc-real-name" title="' + theUILang.autodlYourRealName + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-irc-real-name" title="' + theUILang.autodlYourRealName + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td colspan="4">' + theUILang.autodlIrcOutputDesc + '</td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-irc-server">' + theUILang.autodlOutputServer + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-irc-server" title="' + theUILang.autodlOutputServerTitle + '" placeholder="' + theUILang.autodlOutputServerEmpty + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-irc-server" title="' + theUILang.autodlOutputServerTitle + '" placeholder="' + theUILang.autodlOutputServerEmpty + '"></input></td>' +
 								'<td><label for="autodl-irc-channel">' + theUILang.autodlOutputChannel + '</label></td>' +
-								'<td><input type="text" class="textbox-13" id="autodl-irc-channel" title="' + theUILang.autodlOutputChannelTitle + '" placeholder="' + theUILang.autodlOutputChannelEmpty + '"/></td>' +
+								'<td><input type="text" class="textbox-13" id="autodl-irc-channel" title="' + theUILang.autodlOutputChannelTitle + '" placeholder="' + theUILang.autodlOutputChannelEmpty + '"></input></td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>' +
@@ -202,7 +202,7 @@ function(multiSelectDlgBox, okHandler)
 						'<tbody>' +
 							'<tr>' +
 								'<td><label for="autodl-programs-utorrent">' + theUILang.autodlUtorrentExe + '</label></td>' +
-								'<td><input type="text" class="textbox-30" id="autodl-programs-utorrent" title="' + theUILang.autodlTitle42 + '" placeholder="' + theUILang.autodlHint31 + '"/></td>' +
+								'<td><input type="text" class="textbox-30" id="autodl-programs-utorrent" title="' + theUILang.autodlTitle42 + '" placeholder="' + theUILang.autodlHint31 + '"></input></td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>' +
@@ -212,30 +212,30 @@ function(multiSelectDlgBox, okHandler)
 						'<tbody>' +
 							'<tr>' +
 								'<td><label for="autodl-advanced-user-agent">' + theUILang.autodlDownloadUserAgent + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-advanced-user-agent" title="' + theUILang.autodlTitle43 + '" placeholder="' + theUILang.autodlHint32 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-advanced-user-agent" title="' + theUILang.autodlTitle43 + '" placeholder="' + theUILang.autodlHint32 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-advanced-max-download-retry-time">' + theUILang.autodlMaxDlRetryTime + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-advanced-max-download-retry-time" title="' + theUILang.autodlTitle46 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-advanced-max-download-retry-time" title="' + theUILang.autodlTitle46 + '"></input></td>' +
 								'<td><label for="autodl-advanced-max-download-retry-time">' + theUILang.autodlSeconds + '</label></td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td><label for="autodl-advanced-output-level">' + theUILang.autodlOutputLevel + '</label></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-output-level" title="' + theUILang.autodlTitle47 + '"/></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-output-level" title="' + theUILang.autodlTitle47 + '"></input></td>' +
 							'</tr>' +
 							'<tr>' +
-								'<td><input type="button" id="autodl-advanced-output-sites-button" class="Button" value="' + theUILang.autodlAdvancedOutputSites + '" /></td>' +
-								'<td><input type="text" class="textbox-20" id="autodl-advanced-output-sites" title="' + theUILang.autodlTitle61 + '" placeholder="' + theUILang.autodlHint4 + '"/></td>' +
+								'<td><input type="button" id="autodl-advanced-output-sites-button" class="Button" value="' + theUILang.autodlAdvancedOutputSites + '"></input></td>' +
+								'<td><input type="text" class="textbox-20" id="autodl-advanced-output-sites" title="' + theUILang.autodlTitle61 + '" placeholder="' + theUILang.autodlHint4 + '"></input></td>' +
 							'</tr>' +
 						'</tbody>' +
 					'</table>' +
-					'<input type="checkbox" id="autodl-advanced-debug" title="' + theUILang.autodlTitle48 + '"/>' +
+					'<input type="checkbox" id="autodl-advanced-debug" title="' + theUILang.autodlTitle48 + '"></input>' +
 					'<label for="autodl-advanced-debug" title="' + theUILang.autodlTitle48 + '">' + theUILang.autodlDebug + '</label>' +
 				'</div>' +
 			'</div>' +
 			'<div class="aright buttons-list dialog-buttons">' +
-				'<input type="button" id="autodl-prefs-ok-button" value="' + theUILang.ok + '" class="OK Button" />' +
-				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button" />' +
+				'<input type="button" id="autodl-prefs-ok-button" value="' + theUILang.ok + '" class="OK Button"></input>' +
+				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button"></input>' +
 			'</div>' +
 		'</div>'
 	);
@@ -301,7 +301,7 @@ function(multiSelectDlgBox, okHandler)
 
 	this.advancedOutputSitesButton = new SitesButton("autodl-advanced-output-sites-button", "autodl-advanced-output-sites", multiSelectDlgBox);
 
-	$("#autodl-prefs-ok-button").click(function(e) { okHandler() });
+	$("#autodl-prefs-ok-button").on('click', function(e) { okHandler() });
 }
 
 Preferences.prototype.onBeforeShow =

--- a/js/Servers.js
+++ b/js/Servers.js
@@ -35,32 +35,32 @@ function(multiSelectDlgBox, okHandler)
 				'<p>' + theUILang.autodlCantEditHere + '</p>' +
 			'</div>' +
 			'<div id="autodl-servers-left">' +
-				'<div id="autodl-servers-list" />' +
+				'<div id="autodl-servers-list"></div>' +
 			'</div>' +
 			'<div id="autodl-servers-right">' +
 				'<table>' +
 					'<tbody>' +
 						'<tr>' +
 							'<td><label for="autodl-servers-network">' + theUILang.autodlNetwork + '</label></td>' +
-							'<td><input type="text" class="textbox-18" id="autodl-servers-network" /></td>' +
+							'<td><input type="text" class="textbox-18" id="autodl-servers-network"></input></td>' +
 						'</tr>' +
 						'<tr>' +
 							'<td><label for="autodl-servers-servers">' + theUILang.autodlServer + '</label></td>' +
-							'<td><input type="text" class="textbox-18" id="autodl-servers-servers" /></td>' +
+							'<td><input type="text" class="textbox-18" id="autodl-servers-servers"></input></td>' +
 						'</tr>' +
 						'<tr>' +
 							'<td><label for="autodl-servers-channels">' + theUILang.autodlChannels + '</label></td>' +
-							'<td><input type="text" class="textbox-18" id="autodl-servers-channels" /></td>' +
+							'<td><input type="text" class="textbox-18" id="autodl-servers-channels"></input></td>' +
 						'</tr>' +
 						'<tr>' +
 							'<td><label for="autodl-servers-announcers">' + theUILang.autodlAnnouncer + '</label></td>' +
-							'<td><input type="text" class="textbox-18" id="autodl-servers-announcers" /></td>' +
+							'<td><input type="text" class="textbox-18" id="autodl-servers-announcers"></input></td>' +
 						'</tr>' +
 					'</tbody>' +
 				'</table>' +
 			'</div>' +
 			'<div class="aright buttons-list dialog-buttons">' +
-				'<input type="button" id="autodl-servers-close-button" value="' + theUILang.autodlClose + '" class="Button" />' +
+				'<input type="button" id="autodl-servers-close-button" value="' + theUILang.autodlClose + '" class="Button"></input>' +
 			'</div>' +
 		'</div>'
 	);
@@ -72,7 +72,7 @@ function(multiSelectDlgBox, okHandler)
 	this.trackerListBox = new ListBox("autodl-servers-list");
 	this.trackerListBox.onSelected = function(oldObj, newObj) { this_._onTrackerSelected(oldObj, newObj); }
 
-	$("#autodl-servers-close-button").click(function(e) { okHandler() });
+	$("#autodl-servers-close-button").on('click', function(e) { okHandler() });
 }
 
 Servers.prototype.onOkClicked =
@@ -131,7 +131,7 @@ function(trackerInfos)
 				server: server,
 				trackerInfo: trackerInfo
 			};
-			obj.labelElem = $('<label />').text(trackerInfo.longName)[0];
+			obj.labelElem = $('<label></label>').text(trackerInfo.longName)[0];
 
 			this.trackerListBox.append(obj.labelElem, obj);
 		}

--- a/js/Tabs.js
+++ b/js/Tabs.js
@@ -107,7 +107,7 @@ function(idTabElem, idContentElem)
 	var obj = TabsBase.prototype.add.call(this, idTabElem, idContentElem);
 
 	var this_ = this;
-	$(obj.tabElem).mousedown(function(e)
+	$(obj.tabElem).on('mousedown', function(e)
 	{
 		this_._setNewSelected(obj);
 	});
@@ -139,9 +139,9 @@ function DropDownTabs(idSelect)
 	this.selectElem = document.getElementById(idSelect);
 
 	var this_ = this;
-	$(this.selectElem).change(function(e) { this_._onChange(); })
+	$(this.selectElem).on('change', function(e) { this_._onChange(); })
 						// selectedIndex should be updated when we get a keyup event
-					  .keyup(function(e) { this_._onChange(); });
+					  .on('keyup', function(e) { this_._onChange(); });
 }
 DropDownTabs.prototype = new TabsBase();
 DropDownTabs.constructor = DropDownTabs;

--- a/js/Trackers.js
+++ b/js/Trackers.js
@@ -32,12 +32,12 @@ function(multiSelectDlgBox, okHandler)
 	theDialogManager.make("autodl-trackers", theUILang.autodlTrackers,
 		'<div id="autodl-trackers">' +
 			'<div id="autodl-trackers-left">' +
-				'<div id="autodl-trackers-list" />' +
+				'<div id="autodl-trackers-list"></div>' +
 			'</div>' +
-			'<div id="autodl-trackers-right" />' +
+			'<div id="autodl-trackers-right"></div>' +
 			'<div class="aright buttons-list dialog-buttons">' +
-				'<input type="button" id="autodl-trackers-ok-button" value="' + theUILang.ok + '" class="OK Button" />' +
-				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button" />' +
+				'<input type="button" id="autodl-trackers-ok-button" value="' + theUILang.ok + '" class="OK Button"></input>' +
+				'<input type="button" value="' + theUILang.Cancel + '" class="Cancel Button"></input>' +
 			'</div>' +
 		'</div>'
 	);
@@ -47,7 +47,7 @@ function(multiSelectDlgBox, okHandler)
 	this.trackerListBox = new ListBox("autodl-trackers-list");
 	this.trackerListBox.onSelected = function(oldObj, newObj) { this_._onTrackerSelected(oldObj, newObj); }
 
-	$("#autodl-trackers-ok-button").click(function(e) { okHandler() });
+	$("#autodl-trackers-ok-button").on('click', function(e) { okHandler() });
 }
 
 Trackers.prototype._getSortedTrackerInfos =
@@ -177,8 +177,8 @@ function()
 			trackerInfo: trackerInfo
 		};
 		var checkboxId = this._settingIdFromName(trackerInfo, "enabled");
-		obj.checkboxElem = $('<input type="checkbox" />').attr("id", checkboxId)[0];
-		obj.labelElem = $('<label />').text(trackerInfo.longName)[0];
+		obj.checkboxElem = $('<input type="checkbox"></input>').attr("id", checkboxId)[0];
+		obj.labelElem = $('<label></label>').text(trackerInfo.longName)[0];
 
 		this.trackerListBox.append($(obj.checkboxElem).add(obj.labelElem), obj);
 	}
@@ -221,7 +221,7 @@ function(oldObj, newObj)
 Trackers.prototype._createTrackerContent =
 function(trackerInfo)
 {
-	var div = $("<div />").attr("id", this._id(trackerInfo));
+	var div = $("<div></div>").attr("id", this._id(trackerInfo));
 
 	var settings = trackerInfo.settings;
 	var tbody = null;
@@ -237,19 +237,19 @@ function(trackerInfo)
 
 		if (setting.type === "textbox" || setting.type === "integer")
 		{
-			elem = $('<tr />').append($('<td />').append(elem[0]))
-							.append($('<td />').append(elem[1]));
+			elem = $('<tr></tr>').append($('<td></td>').append(elem[0]))
+							.append($('<td></td>').append(elem[1]));
 
 			if (tbody == null)
 			{
-				tbody = $('<tbody />');
-				div.append($('<br /><table />').append(tbody));
+				tbody = $('<tbody></tbody>');
+				div.append($('<br></br><table></tabel>').append(tbody));
 			}
 			tbody.append(elem);
 		}
 		else
 		{
-			elem = $('<div />').append(elem);
+			elem = $('<div></div>').append(elem);
 			div.append(elem);
 		}
 	}
@@ -266,25 +266,25 @@ function(setting, trackerInfo)
 	switch (setting.type)
 	{
 	case "bool":
-		var checkbox = $('<input type="checkbox" />').attr("id", id).attr("title", tooltipText);
-		var label = $('<label />').attr("for", id).text(setting.text).attr("title", tooltipText);
+		var checkbox = $('<input type="checkbox"></input>').attr("id", id).attr("title", tooltipText);
+		var label = $('<label></label>').attr("for", id).text(setting.text).attr("title", tooltipText);
 		return checkbox.add(label);
 
 	case "textbox":
 	case "integer":
-		var label = $('<label />').attr("for", id).text(setting.text);
-		var textbox = $('<input type="text" class="textbox-22" />')
+		var label = $('<label></label>').attr("for", id).text(setting.text);
+		var textbox = $('<input type="text" class="textbox-22"></input>')
 							.attr("id", id)
 							.attr("title", tooltipText)
 							.attr("placeholder", setting.placeholder || "");
 		if (setting.pasteRegex && setting.pasteGroup)
 		{
 			var this_ = this;
-			textbox.change(function(e)
+			textbox.on('change', function(e)
 			{
 				this_._onPaste(trackerInfo, setting.pasteGroup, textbox);
 			});
-			textbox.keyup(function(e)
+			textbox.on('keyup', function(e)
 			{
 				this_._onPaste(trackerInfo, setting.pasteGroup, textbox);
 			});

--- a/js/Trackers.js
+++ b/js/Trackers.js
@@ -243,7 +243,7 @@ function(trackerInfo)
 			if (tbody == null)
 			{
 				tbody = $('<tbody></tbody>');
-				div.append($('<br></br><table></tabel>').append(tbody));
+				div.append($('<br></br><table></table>').append(tbody));
 			}
 			tbody.append(elem);
 		}


### PR DESCRIPTION
**Please note:** I was not able to setup a proper testing environment for this pull request. Testing was limited to what I could find without setting up `autodl-irssi` and using the jQuery migration plugin. I require help testing this pull request.

The latest updates to ruTorrent can be downloaded from the master branch here:  https://github.com/Novik/ruTorrent

**What does this pull request fix?**
1. This pull request addresses a commit with ruTorrent where the utility functions were changed. https://github.com/Novik/ruTorrent/pull/2247

2. This pull request also addresses a commit with ruTorrent where the jQuery version was upgraded to 3.6.
https://github.com/Novik/ruTorrent/pull/2236

**What are the fixes for this pull request?**
1.  With the change in utility functions for ruTorrent, we must now access them from their respective classes. They are no longer in the global scope. They now must be accessed from static class methods. 

2. With the upgrade of JQuery to version 3.6 we must change the syntax of our JavaScript files to match new stricter rules:

- The usage of short hands are now depreciated for JavaScript events.

It is no longer recommended to use:
```
$("#autodl-log-backup-button").click(function()
{
	backupIframe.attr("src", "plugins/autodl-irssi/getfile.php?file=autodl.cfg");
});
```
Instead we should do this:
```
$("#autodl-log-backup-button").on('click', function()
{
	backupIframe.attr("src", "plugins/autodl-irssi/getfile.php?file=autodl.cfg");
});
```

- Self closing HTML tags are no longer allowed. They are interrupted as invalid by the later versions of jQuery.
We can no longer do this: `<div id="autodl-filters-list"/>` instead we must do this: `<div id="autodl-filters-list"></div>`.